### PR TITLE
REP-11: Protocol Upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ REP stands for RSS3 Evolution Proposal, a detailed documentation proposed by the
 
 This repository tracks all REPs proposed by the RSS3 Community.
 
-| REP Number               | Title                  | Proposer(s)     | Type    | Status |
-| ------------------------ | ---------------------- | --------------- | ------- | ------ |
-| [REP-1](./REPs/REP-1.md) | Purpose and Guidelines | <henry@rss3.io> | Process | Living |
+| REP Number                 | Title                  | Proposer(s)     | Type     | Status |
+| -------------------------- | ---------------------- | --------------- | -------- | ------ |
+| [REP-1](./REPs/REP-1.md)   | Purpose and Guidelines | <henry@rss3.io> | Process  | Living |
+| [REP-11](./REPs/REP-11.md) | Protocol Upgrade       | <henry@rss3.io> | Protocol | Draft  |
 
 ## License
 

--- a/REPs/REP-11.md
+++ b/REPs/REP-11.md
@@ -1,0 +1,59 @@
+```
+REP: REP-11
+Title: Protocol Upgrade
+Status: Draft
+Type: Protocol
+Created: 22 Jan 2024
+Author(s): henry@rss3.io
+Description: This REP describes the process of upgrading the RSS3 Protocol v0.4.0-rc.1 to v1.0.0.
+Discussions: <https://forum.rss3.io/t/rss3-protocol-upgrade/65>
+```
+
+# REP-11: RSS3 Protocol Upgrade
+
+## Table of Contents
+
+- [Abstract](#abstract)
+- [Motivation](#motivation)
+- [Specification](#specification)
+- [Rationale](#rationale)
+
+## Abstract
+
+This REP proposes to upgrade the RSS3 Protocol, based on the RSS3 Unified Metadata Schemas.
+
+## Motivation
+
+The RSS3 Protocol v0.4.0-rc.1 was the last version released through community consensus.
+Following this, the RSS3 Core Devs have been dedicating their efforts to the RSS3 Unified Metadata Schemas (UMS), which has been implemented as the structures for circulating Open Information on the RSS3 DSL > v0.4.
+
+Upgrading the RSS3 Protocol with UMS means that the Protocol will see its first stable and production-grade version, and also align with ongoing advancements in the DSL.
+
+## Specification
+
+See [RSS3 Protocol v1.0.0](https://github.com/RSS3-Network/Protocol/blob/v1.0.0/versions/v1.0.0/main.adoc) for the full specification.
+
+Note: the specification is a work in progress due to the complexity of the Protocol.
+
+## Rationale
+
+The RSS3 Protocol v0.4.0-rc.1 was a file-based solution for storing and circulating Open Information.
+The approach was chosen to navigate the uncertainties of the Open Web at that time.
+It was designed to be simple and easy to use, but it also had its limitations:
+
+1. Scalability - it simply could not handle large amounts of data
+2. Performance - the query speed was slow
+3. Storage Cost - the storage cost was high
+4. Interoperability - it was difficult for developers to build on top of the Protocol
+
+The landscape of the Open Web has also changed a lot since the release of v0.4.0-rc.1, and the RSS3 Core Devs have been working on the RSS3 Unified Metadata Schemas (UMS) to align with the new trends.
+
+The UMS is essentially a set of JSON schemas that define the structures of Open Information.
+The storage of Open Information is no longer limited to files, but can be stored in any relational database, in this case, the RSS3 Core Devs have chosen to use CockroachDB.
+
+The UMS addresses all the problems of the RSS3 Protocol v0.4.0-rc.1:
+
+1. Scalability - the current DSL hosts 1.5b+ pieces of Open Information
+2. Performance - the query speed is lightning fast
+3. Storage Cost - the storage cost is much lower
+4. Interoperability - it provides a set of APIs for developers to build on top of the Protocol

--- a/REPs/REP-Template.md
+++ b/REPs/REP-Template.md
@@ -5,7 +5,7 @@ Status: Draft
 Type: Protocol
 Created: 22 Jan 2024
 Author(s): henry@rss3.io
-Description: This REP describes the process of upgrading the RSS3 Protocol to a new version.
+Description: This REP describes the process of upgrading the RSS3 Protocol v0.4.0-rc.1 to v1.0.0.
 Discussions: <https://forum.rss3.io/t/rss3-protocol-upgrade/65>
 ```
 

--- a/REPs/REP-Template.md
+++ b/REPs/REP-Template.md
@@ -1,59 +1,39 @@
 ```
-REP: REP-Template
-Title: RSS3 Protocol Upgrade
+REP: 0
+Title: REP Template
 Status: Draft
-Type: Protocol
-Created: 22 Jan 2024
-Author(s): henry@rss3.io
-Description: This REP describes the process of upgrading the RSS3 Protocol v0.4.0-rc.1 to v1.0.0.
-Discussions: <https://forum.rss3.io/t/rss3-protocol-upgrade/65>
+Type: Core/Protocol/Process/Informational
+Created: 01 Jan 1970
+Author(s): jane@doe.com
+Description: This is a template for drafting new REPs.
+Discussions: <https://forum.rss3.io/t/how-to-start-an-rep/39>
 ```
 
-# REP-Template: RSS3 Protocol Upgrade
+# REP-Template: REP Template
 
 ## Table of Contents
 
 - [Abstract](#abstract)
+  - [***This is not an official REP***](#this-is-not-an-official-rep)
+  - [***This is not an official REP***](#this-is-not-an-official-rep-1)
 - [Motivation](#motivation)
 - [Specification](#specification)
 - [Rationale](#rationale)
 
 ## Abstract
 
-This REP proposes to upgrade the RSS3 Protocol, based on the RSS3 Unified Metadata Schemas.
+### ***This is not an official REP***
+
+This is a template for drafting new REPs. Please check [REP-1](./REP-1.md) for the optional sections.
+
+1. Duplicate this template and fill in the blank sections to create a new REP.
+2. Please ensure the REP number corresponds directly with your pull request number. For instance, a pull request at `https://github.com/RSS3-Network/REPs/pull/11` should be designated as `REP-11`. To assign a number to your REP, initiate a new pull request.
+3. Update the [List of REPs](https://github.com/RSS3-Network/REPs/blob/main/README.md#list-of-reps) to include your REP.
+
+### ***This is not an official REP***
 
 ## Motivation
 
-The RSS3 Protocol v0.4.0-rc.1 was the last version released through community consensus.
-Following this, the RSS3 Core Devs have been dedicating their efforts to the RSS3 Unified Metadata Schemas (UMS), which has been implemented as the structures for circulating Open Information on the RSS3 DSL > v0.4.
-
-Upgrading the RSS3 Protocol with UMS means that the Protocol will see its first stable and production-grade version, and also align with ongoing advancements in the DSL.
-
 ## Specification
 
-See [RSS3 Protocol v1.0.0](https://github.com/RSS3-Network/Protocol/blob/v1.0.0/versions/v1.0.0/main.adoc) for the full specification.
-
-Note: the specification is a work in progress due to the complexity of the Protocol.
-
 ## Rationale
-
-The RSS3 Protocol v0.4.0-rc.1 was a file-based solution for storing and circulating Open Information.
-The approach was chosen to navigate the uncertainties of the Open Web at that time.
-It was designed to be simple and easy to use, but it also had its limitations:
-
-1. Scalability - it simply could not handle large amounts of data
-2. Performance - the query speed was slow
-3. Storage Cost - the storage cost was high
-4. Interoperability - it was difficult for developers to build on top of the Protocol
-
-The landscape of the Open Web has also changed a lot since the release of v0.4.0-rc.1, and the RSS3 Core Devs have been working on the RSS3 Unified Metadata Schemas (UMS) to align with the new trends.
-
-The UMS is essentially a set of JSON schemas that define the structures of Open Information.
-The storage of Open Information is no longer limited to files, but can be stored in any relational database, in this case, the RSS3 Core Devs have chosen to use CockroachDB.
-
-The UMS addresses all the problems of the RSS3 Protocol v0.4.0-rc.1:
-
-1. Scalability - the current DSL hosts 1.5b+ pieces of Open Information
-2. Performance - the query speed is lightning fast
-3. Storage Cost - the storage cost is much lower
-4. Interoperability - it provides a set of APIs for developers to build on top of the Protocol

--- a/REPs/REP-Template.md
+++ b/REPs/REP-Template.md
@@ -1,34 +1,59 @@
 ```
 REP: REP-Template
-Title: REP Template
+Title: RSS3 Protocol Upgrade
 Status: Draft
-Type: Core/Protocol/Process/Informational
-Created: 01 Jan 1970
-Author(s): jane@doe.com
-Description: This is a template for drafting new REPs.
-Discussions: <https://forum.rss3.io/t/how-to-start-an-rep/39>
+Type: Protocol
+Created: 22 Jan 2024
+Author(s): henry@rss3.io
+Description: This REP describes the process of upgrading the RSS3 Protocol to a new version.
+Discussions: <https://forum.rss3.io/t/rss3-protocol-upgrade/65>
 ```
 
-# REP-Template: REP Template
+# REP-Template: RSS3 Protocol Upgrade
 
 ## Table of Contents
 
+- [Abstract](#abstract)
+- [Motivation](#motivation)
+- [Specification](#specification)
+- [Rationale](#rationale)
+
 ## Abstract
 
-### ***This is not an official REP***
-
-This is a template for drafting new REPs.
-
-Duplicate this file and fill in the blank sections to create a new REP. Add optional sections when needed.
-
-Use `REP-Template` for all drafts (and assets when applicable), the Editors will assign a new number when the REP is ready to be merged.
-
-Please check [REP-1](./REP-1.md) for the format.
-
-### ***This is not an official REP***
+This REP proposes to upgrade the RSS3 Protocol, based on the RSS3 Unified Metadata Schemas.
 
 ## Motivation
 
+The RSS3 Protocol v0.4.0-rc.1 was the last version released through community consensus.
+Following this, the RSS3 Core Devs have been dedicating their efforts to the RSS3 Unified Metadata Schemas (UMS), which has been implemented as the structures for circulating Open Information on the RSS3 DSL > v0.4.
+
+Upgrading the RSS3 Protocol with UMS means that the Protocol will see its first stable and production-grade version, and also align with ongoing advancements in the DSL.
+
 ## Specification
 
+See [RSS3 Protocol v1.0.0](https://github.com/RSS3-Network/Protocol/blob/v1.0.0/versions/v1.0.0/main.adoc) for the full specification.
+
+Note: the specification is a work in progress due to the complexity of the Protocol.
+
 ## Rationale
+
+The RSS3 Protocol v0.4.0-rc.1 was a file-based solution for storing and circulating Open Information.
+The approach was chosen to navigate the uncertainties of the Open Web at that time.
+It was designed to be simple and easy to use, but it also had its limitations:
+
+1. Scalability - it simply could not handle large amounts of data
+2. Performance - the query speed was slow
+3. Storage Cost - the storage cost was high
+4. Interoperability - it was difficult for developers to build on top of the Protocol
+
+The landscape of the Open Web has also changed a lot since the release of v0.4.0-rc.1, and the RSS3 Core Devs have been working on the RSS3 Unified Metadata Schemas (UMS) to align with the new trends.
+
+The UMS is essentially a set of JSON schemas that define the structures of Open Information.
+The storage of Open Information is no longer limited to files, but can be stored in any relational database, in this case, the RSS3 Core Devs have chosen to use CockroachDB.
+
+The UMS addresses all the problems of the RSS3 Protocol v0.4.0-rc.1:
+
+1. Scalability - the current DSL hosts 1.5b+ pieces of Open Information
+2. Performance - the query speed is lightning fast
+3. Storage Cost - the storage cost is much lower
+4. Interoperability - it provides a set of APIs for developers to build on top of the Protocol


### PR DESCRIPTION
Title: Protocol Upgrade
Status: Draft
Type: Protocol
Created: 22 Jan 2024
Author(s): henry@rss3.io
Description: This REP describes the process of upgrading the RSS3 Protocol v0.4.0-rc.1 to v1.0.0.
Discussions: <https://forum.rss3.io/t/rss3-protocol-upgrade/65>