### PR TITLE
REP-1: update REP Editor Responsibilities and REP Template

### DIFF
--- a/REPs/REP-1.md
+++ b/REPs/REP-1.md
@@ -24,7 +24,7 @@ Created: 19 Jan 2024
 
 ## What is an REP?
 
-REP stands for RSS3 Evolution Proposal. Each REP is a document providing information to the RSS3 Community, with regards to all components of the RSS3 Network, such as RSS3 Data Sublayer (DSL) and RSS3 Value Sublayer (VSL). The REP should offer a concise technical specification of the feature or improvement and its rationale. Every REP proposer is responsible for building consensus within the Community and documenting any dissenting opinions. Each REP is identified by a unique index number by the REP Editors.
+REP stands for RSS3 Evolution Proposal. Each REP is a document providing information to the RSS3 Community, with regards to all components of the RSS3 Network, such as RSS3 Data Sublayer (DSL) and RSS3 Value Sublayer (VSL). The REP should offer a concise technical specification of the feature or improvement and its rationale. Every REP proposer is responsible for building consensus within the Community and documenting any dissenting opinions. Each REP is identified by a unique index number.
 
 ## REP Rationale
 
@@ -43,7 +43,7 @@ There are four types of REP:
 
 ![REP workflow](REP-1/REP-workflow.png)
 
-*Figure 1: REP workflow*
+_Figure 1: REP workflow_
 
 REPs have the following states:
 
@@ -118,13 +118,21 @@ The current Team members are:
 
 ## REP Editor Responsibilities
 
-The REP Editors are responsible for the overall management of the REP process, including the following:
+The REP Editors are responsible for the overall management of the REP process, including the following work:
 
-- Reivew initial PRs
-- Assign REP numbers
-- Update REP status
-- Merge PRs
-- Update README
+1. Check the Soundness: evaluate each REP to ensure it is practical, relevant, and free from any objectionable content. Should you find issues, reject the proposal with a detailed explanation, seeking input from fellow Editors as needed.
+2. Check the REP format: check whether the REP follows the [REP Format](#rep-format).
+3. Check the REP number: check whether the REP number is aligned with the PR number.
+4. Check the REP type: check whether the REP type is aligned with the [REP Types](#rep-types).
+5. Check the REP status: check whether the REP status is consistent with the steps outlined in the [REP Workflow](#rep-workflow).
+   1. Every REP must begin in `Draft`
+   2. Status progresses only 1 step per PR.
+   3. Prior to advancing into `Candidate`, ensure all dissenting opinions have been properly addressed.
+   4. Advancement to `Final` requires approval from at least two REP Editors.
+6. Check the [List of REPs](https://github.com/RSS3-Network/REPs/blob/main/README.md#list-of-reps) is updated.
+7. Check the PR title:
+   1. The initial PR title should be formatted as `REP-{number}: {REP title}`.
+   2. Subsequent PR titles should indicate changes, formatted as `REP-{number}: {what's changed}`.
 
 ## Reference
 

--- a/REPs/REP-1.md
+++ b/REPs/REP-1.md
@@ -36,7 +36,7 @@ There are four types of REP:
 
 - **Core**: A Core REP describes functional changes to the RSS3 Network, such as changes to Sublayer parameters, DSL routing algorithm and epoch length. It will affect the implementation of the RSS3 Network.
 - **Protocol**: A Protocol REP changes the RSS3 Protocol, affecting how Open Information is structured and delivered to the end users on the DSL. It will affect the implementation of the RSS3 Network.
-- **Process**: A Process REP changes the workflow or governance process of the RSS3 network, like this REP itself. It will not affect the implementation of the RSS3 Network.
+- **Process**: A Process REP changes the workflow or governance process of the RSS3 Network, like this REP itself. It will not affect the implementation of the RSS3 Network.
 - **Informational**: An Informational REP clarifies concepts within the RSS3 Network. It will not affect the implementation of the RSS3 Network.
 
 ## REP Workflow

--- a/REPs/REP-Template.md
+++ b/REPs/REP-Template.md
@@ -1,5 +1,5 @@
 ```
-REP: REP-Template
+REP: 0
 Title: REP Template
 Status: Draft
 Type: Core/Protocol/Process/Informational
@@ -13,17 +13,22 @@ Discussions: <https://forum.rss3.io/t/how-to-start-an-rep/39>
 
 ## Table of Contents
 
+- [Abstract](#abstract)
+  - [***This is not an official REP***](#this-is-not-an-official-rep)
+  - [***This is not an official REP***](#this-is-not-an-official-rep-1)
+- [Motivation](#motivation)
+- [Specification](#specification)
+- [Rationale](#rationale)
+
 ## Abstract
 
 ### ***This is not an official REP***
 
-This is a template for drafting new REPs.
+This is a template for drafting new REPs. Please check [REP-1](./REP-1.md) for the optional sections.
 
-Duplicate this file and fill in the blank sections to create a new REP. Add optional sections when needed.
-
-Use `REP-Template` for all drafts (and assets when applicable), the Editors will assign a new number when the REP is ready to be merged.
-
-Please check [REP-1](./REP-1.md) for the format.
+1. Duplicate this template and fill in the blank sections to create a new REP.
+2. Please ensure the REP number corresponds directly with your pull request number. For instance, a pull request at `https://github.com/RSS3-Network/REPs/pull/11` should be designated as `REP-11`. To assign a number to your REP, initiate a new pull request.
+3. Update the [List of REPs](https://github.com/RSS3-Network/REPs/blob/main/README.md#list-of-reps) to include your REP.
 
 ### ***This is not an official REP***
 


### PR DESCRIPTION
Further clarify the REP Editor Responsibilities and the REP submission process. 

REP number is now corresponding to the PR number, this streamlines the entire process, and reduces the amount of work for both the proposer and editors.